### PR TITLE
Fixing devise migrations working with old data

### DIFF
--- a/app/models/instructor.rb
+++ b/app/models/instructor.rb
@@ -7,6 +7,7 @@ class Instructor < ActiveRecord::Base
   end
 
   def name
+    return read_attribute(:name) if has_attribute?(:name)
     user.name
   end
 
@@ -22,7 +23,7 @@ class Instructor < ActiveRecord::Base
     office_hours_end.strftime("%H:%M")
   end
 
-  def has_student? student
+  def has_student?(student)
     self.id == student.cohort.instructor_id
   end
 

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -11,6 +11,7 @@ class Student < ActiveRecord::Base
   validates_presence_of :cohort
 
   def name
+    return read_attribute(:name) if has_attribute?(:name)
     user.name
   end
 


### PR DESCRIPTION
The `name` method was causing the data migrations to explode. This should fix that.