### PR TITLE
Trying to fix cohort redirect

### DIFF
--- a/app/controllers/cohorts_controller.rb
+++ b/app/controllers/cohorts_controller.rb
@@ -1,6 +1,7 @@
 class CohortsController < ApplicationController
-  after_action :verify_authorized, :except => :index
+  after_action :verify_authorized, :except => [:index, :my]
   after_action :verify_policy_scoped, :only => :index
+
   def show
     @cohort      = Cohort.find(params[:id]).decorate
     authorize @cohort
@@ -14,10 +15,11 @@ class CohortsController < ApplicationController
   end
 
   def my
-    if current_user && current_user.student?
-      redirect_to cohort_path(current_user.student.cohort)
+    if current_user
+      redirect_to cohort_path(current_user.student.cohort) if current_user.student?
+      redirect_to staff_cohorts_path if current_user.instructor?
     else
-      render "Not enrolled"
+      redirect_to '/404', alert: "Not enrolled in a cohort. Contact your instructor."
     end
   end
 

--- a/app/models/instructor.rb
+++ b/app/models/instructor.rb
@@ -7,6 +7,7 @@ class Instructor < ActiveRecord::Base
   end
 
   def name
+    return read_attribute(:name) if has_attribute?(:name)
     user.name
   end
 
@@ -22,7 +23,7 @@ class Instructor < ActiveRecord::Base
     office_hours_end.strftime("%H:%M")
   end
 
-  def has_student? student
+  def has_student?(student)
     self.id == student.cohort.instructor_id
   end
 

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -11,6 +11,7 @@ class Student < ActiveRecord::Base
   validates_presence_of :cohort
 
   def name
+    return read_attribute(:name) if has_attribute?(:name)
     user.name
   end
 


### PR DESCRIPTION
When logging in as an instructor I was given the error "no template 'Not enrolled' found for cohort or application".

I tried to make this have a sensible fallback, so right now instructors go to the cohort index and if they aren't a student or an instructor they get redirected to the 404 page with an alert message.