### PR TITLE
Students signup with cohort param pass in.

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,18 @@
+class RegistrationsController < Devise::RegistrationsController
+  def new
+    @cohort = Cohort.find(params[:cohort_id]) if params[:cohort_id]
+    super
+  end
+
+  def create
+    super do |resource|
+      resource.student = Student.new(cohort_id: params[:cohort_id])
+      resource.save
+    end
+  end
+
+  def update
+    super
+  end
+end
+

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,7 +1,11 @@
 <div class='col-sm-4 col-sm-offset-4'>
-  <h2>Sign up</h2>
+  <% if @cohort %>
+    <h2>Sign up for <%= @cohort.name.titleize %> <small><%= @cohort.campus.name %></small></h2>
+  <% else %>
+    <h2>Sign up</h2>
+  <% end %>
 
-  <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name, cohort_id: (@cohort.present? ? @cohort.id : nil))) do |f| %>
     <%= f.error_notification %>
 
     <div class="form-inputs">
@@ -9,8 +13,6 @@
       <%= f.input :password, required: true, hint: ("#{@minimum_password_length} characters minimum" if @validatable) %>
       <%= f.input :password_confirmation, required: true %>
     </div>
-
-    <%= render partial: "#{resource_name.to_s.pluralize}/fields", locals: { :f => f } %>
 
     <div class="form-actions">
       <%= f.button :submit, "Sign up" %>

--- a/app/views/staff/cohorts/_nav.html.slim
+++ b/app/views/staff/cohorts/_nav.html.slim
@@ -9,3 +9,4 @@
         li = active_link_to t('.days'), staff_cohort_days_path(cohort), class: 'btn btn-primary'
         li = active_link_to t('.new-assignment'), new_staff_cohort_assignment_path(cohort), class: 'btn btn-primary'
         li = active_link_to t('.new-badge'), new_staff_badge_path, class: 'btn btn-primary'
+        li = text_field_tag 'Signup link', url_for(only_path: false, controller: '/registrations', action: :new, cohort_id: cohort.id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { registrations: 'registrations' }
 
   resources :reports
   resources :instructors


### PR DESCRIPTION
The way this works is that each instructor will give their students a link to sign up for their cohort. Should cut down on the amount of students who sign up for the wrong class.

This will probably not be the final design after we rework sign up with google auth, but we need to keep in mind the best way to get new students onboarded when new classes start.

There is a link in the admin dash nav so the instructor can always have that sign up link. It should probably be moved somewhere else eventually and I'd like to use that nice 'copy to clipboard' flash/js plugin that github uses. 