### PR TITLE
Adding Rspec Features

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ group :test, :development do
   gem 'quiet_assets'
   gem 'rspec'
   gem 'rspec-rails'
+  gem 'capybara'
   gem 'rspec-mocks'
   gem 'simplecov'
   gem 'spring', '~> 1.3.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,12 @@ GEM
       uniform_notifier (~> 1.9.0)
     byebug (4.0.4)
       columnize (= 0.9.0)
+    capybara (2.4.4)
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     cd (1.0.0)
     clipboard (1.0.6)
     code (0.9.0)
@@ -395,6 +401,8 @@ GEM
       paint (>= 0.9, < 2.0)
     wkhtmltopdf-binary (0.9.9.3)
     wkhtmltopdf-heroku (2.12.2.1)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
     zonebie (0.5.1)
 
 PLATFORMS
@@ -405,6 +413,7 @@ DEPENDENCIES
   bootstrap-sass
   bullet
   byebug
+  capybara
   codeclimate-test-reporter
   database_cleaner
   devise

--- a/app/controllers/staff/cohorts_controller.rb
+++ b/app/controllers/staff/cohorts_controller.rb
@@ -38,8 +38,9 @@ class Staff::CohortsController < Staff::ApplicationController
   private
 
   def cohort_params
-    params.require(:cohort).permit(:name, :campus_id, :first_day)
+    params.require(:cohort).permit(:name, :instructor_id, :campus_id, :first_day)
   end
+
   def find_cohort
     if current_user && current_user.instructor? && session[:cohort_id]
       redirect_to staff_cohort_path(session[:cohort_id])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,7 +9,7 @@ module ApplicationHelper
   end
 
   def markdown(source)
-    Kramdown::Document.new(source).to_html.html_safe
+    Kramdown::Document.new(source || '').to_html.html_safe
   end
 
   def display_flash(key, msg)

--- a/app/views/staff/cohorts/index.slim
+++ b/app/views/staff/cohorts/index.slim
@@ -8,7 +8,7 @@ table.table.table-hover
   tbody
     - @cohorts.each do |cohort|
       tr
-        td = link_to "Select", staff_cohort_path(cohort), class: "btn btn-primary"
+        td = link_to "Select", staff_cohort_path(cohort), class: "btn btn-primary", 'data-id': cohort.id
         td = cohort.name.titleize
         td = cohort.campus
         td = link_to cohort.instructor.name, cohort.instructor

--- a/config/initializers/refile.rb
+++ b/config/initializers/refile.rb
@@ -8,5 +8,5 @@ Refile.configure do |config|
   }
   Refile.cache = Refile::S3.new(prefix: "cache", **aws)
   Refile.store = Refile::S3.new(prefix: "store", **aws)
-  Refile.host = "//" + ENV['ASSET_HOST'] unless Rails.env.test?
+  Refile.host = "//" + (ENV['ASSET_HOST'] || 'example.com') unless Rails.env.test?
 end

--- a/spec/factories/adjustments.rb
+++ b/spec/factories/adjustments.rb
@@ -2,5 +2,4 @@ FactoryGirl.define do
   factory :adjustment do
     checkin
   end
-
 end

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :cohort do
     name { Faker::App.name }
     campus
+    instructor
     first_day { DateTime.now }
     factory :cohort_w_stuff do
       transient do

--- a/spec/factories/instructors.rb
+++ b/spec/factories/instructors.rb
@@ -1,4 +1,5 @@
 FactoryGirl.define do
   factory :instructor do
+    user
   end
 end

--- a/spec/features/staff_cohorts_spec.rb
+++ b/spec/features/staff_cohorts_spec.rb
@@ -34,19 +34,6 @@ RSpec.feature "StaffCohorts", type: :feature do
     #    Could help isolate especially brittle areas of the test or the code.
     #  - I realize that this tests is taking the big assumption that you will be redirected to the staff_cohorts_index after sign_in
 
-    def sign_in(type)
-      case type
-      when :instructor
-        visit new_user_session_path
-        fill_in 'Email', with: 'instructor@theironyard.com'
-        fill_in 'Password', with: 'password'
-        click_button 'Log in'
-        expect(page).to have_content('Signed in successfully')
-      else
-        raise 'Sign in type not found. Please add a new entry for that type.'
-      end
-    end
-
     def click_new_cohort_link
       find(:css, "a[href='#{new_staff_cohort_path}']").click
     end

--- a/spec/features/staff_cohorts_spec.rb
+++ b/spec/features/staff_cohorts_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.feature "StaffCohorts", type: :feature do
+  let!(:instructor) do
+    create :instructor_user, email: 'instructor@theironyard.com', password: 'password', name: 'Jane Doe'
+  end
+
+  feature 'Picking Cohort' do
+    scenario 'with multiple available cohorts' do
+      create :cohort, name: 'Design Summer', instructor: instructor.instructor
+      rails_cohort = create :cohort, name: 'Rails Summer', instructor: instructor.instructor
+
+      sign_in(:instructor)
+
+      find(:css, "a[data-id='#{rails_cohort.id}']").click
+
+      expect(page).to have_content('Dashboard')
+      expect(page).to have_content('Reports')
+      expect(page).to have_content('New Assignment')
+      expect(page).to have_content('New Badge')
+    end
+
+    scenario 'creating a cohort' do
+      create :campus, name: 'Moon'
+
+      sign_in(:instructor)
+      click_new_cohort_link
+      create_cohort
+      expect_cohort_to_be_created
+    end
+    #Notes about this particular test/scenario:
+    #  - Thought I'd play with the idea of making the scenario as readable as possible
+    #    so when it does break, you're changing the method its using, not the scenario itself.
+    #    Could help isolate especially brittle areas of the test or the code.
+    #  - I realize that this tests is taking the big assumption that you will be redirected to the staff_cohorts_index after sign_in
+
+    def sign_in(type)
+      case type
+      when :instructor
+        visit new_user_session_path
+        fill_in 'Email', with: 'instructor@theironyard.com'
+        fill_in 'Password', with: 'password'
+        click_button 'Log in'
+        expect(page).to have_content('Signed in successfully')
+      else
+        raise 'Sign in type not found. Please add a new entry for that type.'
+      end
+    end
+
+    def click_new_cohort_link
+      find(:css, "a[href='#{new_staff_cohort_path}']").click
+    end
+
+    def create_cohort
+      fill_in 'Name', with: 'Rails'
+      select 'Moon', from: 'Campus'
+      select 'Jane Doe', from: 'Instructor'
+
+      click_button 'Create Cohort'
+    end
+
+    def expect_cohort_to_be_created
+      expect(page).to have_content('New Cohort successfully created!')
+    end
+  end
+end

--- a/spec/features/staff_dashes_spec.rb
+++ b/spec/features/staff_dashes_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.feature "StaffDashes", type: :feature do
+  feature 'The Cohort Dashboard' do
+    scenario 'has assignments, students, susbmissions, and adjustments' do
+    end
+
+    scenario 'viewing assignments' do
+    end
+    scenario 'creating assignments' do
+    end
+
+    scenario 'viewing submissions' do
+    end
+    scenario 'viewing assignments' do
+    end
+
+  end
+end

--- a/spec/features/staff_dashes_spec.rb
+++ b/spec/features/staff_dashes_spec.rb
@@ -2,7 +2,29 @@ require 'rails_helper'
 
 RSpec.feature "StaffDashes", type: :feature do
   feature 'The Cohort Dashboard' do
-    scenario 'has assignments, students, susbmissions, and adjustments' do
+    let!(:instructor) do
+      create :instructor_user, email: 'instructor@theironyard.com', password: 'password', name: 'Jane Doe'
+    end
+
+    scenario 'has assignments, students, submissions, and adjustments' do
+      cohort  = create :cohort, name: 'Rails Summer', instructor: instructor.instructor
+      day     = create :day, cohort: cohort
+      checkin = create :checkin, day: day
+      assignment = create :assignment_w_submissions, cohort: cohort
+      user = create :student_user
+      user.email = Faker::Internet.email
+      user.student.cohort = cohort
+      user.save!
+      create :adjustment, checkin: checkin
+
+      sign_in(:instructor)
+
+      visit staff_cohort_path(cohort)
+
+      expect(page).to have_content(day.decorate.starts_at)
+      expect(page).to have_content(assignment.title)
+      expect(page).to have_content(assignment.submissions.first.link)
+      expect(page).to have_content(user.name)
     end
 
     scenario 'viewing assignments' do

--- a/spec/features/staff_dashes_spec.rb
+++ b/spec/features/staff_dashes_spec.rb
@@ -7,15 +7,7 @@ RSpec.feature "StaffDashes", type: :feature do
     end
 
     scenario 'has assignments, students, submissions, and adjustments' do
-      cohort  = create :cohort, name: 'Rails Summer', instructor: instructor.instructor
-      day     = create :day, cohort: cohort
-      checkin = create :checkin, day: day
-      assignment = create :assignment_w_submissions, cohort: cohort
-      user = create :student_user
-      user.email = Faker::Internet.email
-      user.student.cohort = cohort
-      user.save!
-      create :adjustment, checkin: checkin
+      cohort, day, _, assignment, user, _ = create_full_dash
 
       sign_in(:instructor)
 
@@ -24,17 +16,85 @@ RSpec.feature "StaffDashes", type: :feature do
       expect(page).to have_content(day.decorate.starts_at)
       expect(page).to have_content(assignment.title)
       expect(page).to have_content(assignment.submissions.first.link)
-      expect(page).to have_content(user.name)
+      expect(page).to have_content(/#{user.name}/i)
     end
 
     scenario 'viewing assignments' do
+      cohort, _, _, assignment, _, _ = create_full_dash
+
+      sign_in(:instructor)
+
+      visit staff_cohort_path(cohort)
+
+      click_link_to(staff_cohort_assignment_path(cohort, assignment))
+
+      expect(page).to have_content(assignment.title)
+      expect(page).to have_content(/submit homework/i)
     end
+
     scenario 'creating assignments' do
     end
 
     scenario 'viewing submissions' do
+      cohort, _, _, assignment, _, _ = create_full_dash
+
+      sign_in(:instructor)
+
+      visit staff_cohort_path(cohort)
+
+      click_link_to(submission_path(assignment.submissions.first))
+
+      expect(page).to have_content(/#{assignment.submissions.first.student.name}'s Submission for #{assignment.title}/i)
     end
-    scenario 'viewing assignments' do
+
+    scenario 'viewing students' do
+      cohort, _, _, assignment, _, _ = create_full_dash
+
+      sign_in(:instructor)
+
+      visit staff_cohort_path(cohort)
+
+      click_link_to(student_path(assignment.submissions.first.student))
+
+      expect(page).to have_content(assignment.submissions.first.student)
+      expect(page).to have_content(/stats/i)
+      expect(page).to have_content(/badges/i)
+      expect(page).to have_content(/blog/i)
+    end
+
+    def click_link_to(path)
+      result = find_link_to(path)
+      if result.respond_to?(:each)
+        result.first.click
+      else
+        result.click
+      end
+    end
+
+    def find_link_to(path)
+      find(:css, "a[href='#{path}']")
+    rescue Capybara::Ambiguous
+      all(:css, "a[href='#{path}']")
+    end
+
+    def create_full_dash
+      cohort  = create :cohort, name: 'Rails Summer', instructor: instructor.instructor
+      day     = create :day, cohort: cohort
+      checkin = create :checkin, day: day
+      assignment = create :assignment_w_submissions, cohort: cohort
+      adjustment = create :adjustment, checkin: checkin
+
+      student = assignment.submissions.first.student
+      student.cohort = cohort
+      student.user = create :user, name: 'Jane Student Smith'
+      student.save!
+
+      user = create :student_user
+      user.email = Faker::Internet.email
+      user.student.cohort = cohort
+      user.save!
+
+      [cohort, day, checkin, assignment, user, adjustment]
     end
 
   end

--- a/spec/features/staff_reports_spec.rb
+++ b/spec/features/staff_reports_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.feature "StaffReports", type: :feature do
+  pending "add some scenarios (or delete) #{__FILE__}"
+end

--- a/spec/features/student_dashes_spec.rb
+++ b/spec/features/student_dashes_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.feature "StudentDashes", type: :feature do
+  pending "add some scenarios (or delete) #{__FILE__}"
+end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Assignment, type: :model do
         am_three.due_date.beginning_of_week.to_date => [ am_three ],
         am_four.due_date.beginning_of_week.to_date  => [ am_four ]
       }
-      expect(Assignment.by_week(records)).to include(result)
+      expect(Assignment.by_week(records)).to eq result
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,16 +4,17 @@ require 'spec_helper'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
 require 'database_cleaner'
-require "pundit/rspec"
+require 'pundit/rspec'
 require 'codeclimate-test-reporter'
 
-ActiveRecord::Migration.maintain_test_schema!
+require 'support/features/session_helpers.rb'
 
+ActiveRecord::Migration.maintain_test_schema!
 CodeClimate::TestReporter.start
 
 RSpec.configure do |config|
+  config.include Features::SessionHelpers, type: :feature
   config.include Devise::TestHelpers, type: :controller
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   config.use_transactional_fixtures = false
 

--- a/spec/support/features/session_helpers.rb
+++ b/spec/support/features/session_helpers.rb
@@ -1,0 +1,16 @@
+module Features
+  module SessionHelpers
+    def sign_in(type)
+      case type
+      when :instructor
+        visit new_user_session_path
+        fill_in 'Email', with: 'instructor@theironyard.com'
+        fill_in 'Password', with: 'password'
+        click_button 'Log in'
+        expect(page).to have_content('Signed in successfully')
+      else
+        raise 'Sign in type not found. Please add a new entry for that type.'
+      end
+    end
+  end
+end


### PR DESCRIPTION
I've still got a lot more to write, but I think its best to get these changes into the code base sooner than later. These aren't meant to be exhaustive and they suffer from [INSERT COMPLAINT OF INTEGRATION SPECS HERE] as expected, but they're relatively fast and will help us get our testing harness up so we don't accidentally break a feature.

These specs focus on picking a cohort and making sure all the appropriate data is rendered (and clickable) on the instructor 'dashboard' which I guess now is the 'cohort show' page. 

Next I'll be adding some more scenarios for students using their dashboard.

Then last will be login/signup and reports. That'll give us pretty good high level coverage of 90% of the app. Will certainly help improve our confidence when merging pull requests and deploying. 