### PR TITLE
Reports with Day selection

### DIFF
--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -26,10 +26,10 @@ class Staff::ReportsController < Staff::ApplicationController
   def create
     @report = Report.new(report_params)
     authorize @report
-    @report.day = @cohort.current_day
     if @report.save
       redirect_to staff_cohort_report_path(@cohort, @report), notice: I18n.t('.created', resource: I18n.t('.report'))
     else
+      flash[:alert] = "Report couldn't be created because #{@report.errors.full_messages.join(', ')}"
       render :new
     end
   end
@@ -40,6 +40,6 @@ class Staff::ReportsController < Staff::ApplicationController
   end
 
   def report_params
-    params.require(:report).permit(:student_id, :participation, :participation_comments, :effort, :effort_comments, :skill, :skill_comments, :overall, :overall_comments, :status)
+    params.require(:report).permit(:student_id, :day_id, :participation, :participation_comments, :effort, :effort_comments, :skill, :skill_comments, :overall, :overall_comments, :status)
   end
 end

--- a/app/views/staff/application/_nav.slim
+++ b/app/views/staff/application/_nav.slim
@@ -37,33 +37,3 @@ css:
           li Student Signup Link
           li = text_field_tag 'Signup link', cohort.sign_up_url, size: cohort.sign_up_url.length
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/app/views/staff/reports/_form.html.slim
+++ b/app/views/staff/reports/_form.html.slim
@@ -1,6 +1,7 @@
 h1 Student Assessment Form
 = simple_form_for @report, url: staff_cohort_reports_path(@cohort), html: { class: 'form' } do |f|
   = f.input :student_id, collection: @cohort.students
+  = f.input :day_id, collection: @cohort.days, selected: @cohort.current_day
   - %i(participation effort skill overall).each do |metric|
     = f.input metric, collection: 1..3, as: :radio_buttons, checked: 3, wrapper_html: { class: 'col-sm-7' }, label_html: { class: 'radio-inline col-sm-3' }, item_wrapper_class: 'radio-inline'
     = f.input "#{metric}_comments".to_sym, as: :text , wrapper_html: { class: 'col-md-5' }

--- a/app/views/staff/reports/show.html.slim
+++ b/app/views/staff/reports/show.html.slim
@@ -1,4 +1,4 @@
-= render partial: 'nav', locals: { cohort: @report.cohort }
+= render partial: 'nav', locals: { cohort: @cohort }
 = link_to "Download PDF", { format: :pdf }, class: 'btn btn-primary'
 .row
   .col-xs-4


### PR DESCRIPTION
Fixed a few bugs relating to generating reports.

Instructors can now select what day the reports are calculating too. There was an issue where reports could not be generated on any other day than the current one, and if there is no current one, you cannot generate any reports. No good. 