### PR TITLE
Changing appearance of dashboard for new instructors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'slim'
 gem 'turbolinks'
 gem 'uglifier', '>= 1.3.0'
 gem 'wicked_pdf'
+gem 'zeroclipboard-rails'
 
 group :development do
   gem 'foreman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -424,6 +424,8 @@ GEM
     wkhtmltopdf-heroku (2.12.2.4)
     xpath (2.0.0)
       nokogiri (~> 1.3)
+    zeroclipboard-rails (0.1.1)
+      railties (>= 3.1)
     zonebie (0.5.1)
 
 PLATFORMS
@@ -494,6 +496,7 @@ DEPENDENCIES
   wicked_pdf
   wkhtmltopdf-binary
   wkhtmltopdf-heroku
+  zeroclipboard-rails
   zonebie
 
 BUNDLED WITH

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,6 +9,7 @@
 //= require marked
 //= require moment
 //= require datetimepicker
+//= require zeroclipboard
 //
 //= require location
 //= require react
@@ -26,6 +27,10 @@ var ready = function() {
         $(".button-collapse").sideNav();
         $('select').material_select();
         jQuery('.datetimepicker').datetimepicker();
+
+        var newInstructorClip = new ZeroClipboard(jQuery('#new-cohort-signup-link-button'));
+        var signup_url_clip   = new ZeroClipboard(jQuery('#cohort-signup-link-button'));
+        var assignment_clip   = new ZeroClipboard(jQuery('#assignment-url-button'));
 
 
         if(_loggedIn && (Location.distance === undefined || Location.distance === 0)) {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -120,3 +120,12 @@ li.collection-item.avatar.padded {
       margin-right: 5px;
     }
 }
+
+
+.copy-to-clipboard-button {
+  top: -5px;
+}
+
+span.right-space {
+  margin-right: 10px;
+}

--- a/app/views/application/_students.html.slim
+++ b/app/views/application/_students.html.slim
@@ -1,4 +1,14 @@
 - unless students.empty?
+- if students.empty?
+  .card.blue.darken-2
+    .card-content.white-text
+      span.card-title = t('.students')
+      p No Students are in this class yet.
+    .card-action
+      button.btn.copy-to-clipboard-button id='new-cohort-signup-link-button' title='Click to copy cohort sign up url to clipboard' data-clipboard-target='cohort-signup-url'
+        | Copy Cohort Signup URL to Clipboard
+        i.material-icons.right description
+- else
   .card.blue.darken-2
     .card-content.white-text
         span.card-title = t('.students')

--- a/app/views/staff/assignments/show.html.slim
+++ b/app/views/staff/assignments/show.html.slim
@@ -1,7 +1,10 @@
 = render partial: 'nav', locals: { cohort: assignment.cohort.decorate}
 .col.s4
   p.muted Student Link:
-  = assignment_url(assignment)
+  span.right-space id='assignment-url' = assignment_url(assignment)
+  a.btn-floating.waves-effect.waves-light.copy-to-clipboard-button id='assignment-url-button' data-clipboard-target='assignment-url' title='Click to copy assignment url to clipboard'
+    i.material-icons description
+
 .row
   h3.col.s12.m8 = assignment.title
   h4.col.s12.m4

--- a/app/views/staff/cohorts/_adjustments.html.slim
+++ b/app/views/staff/cohorts/_adjustments.html.slim
@@ -1,7 +1,9 @@
-- unless adjustments.empty?
-  .card.blue.darken-2
-    .card-content.white-text
-      span.card-title = t('.adjustments')
+.card.blue.darken-2
+  .card-content.white-text
+    span.card-title = t('.adjustments')
+    - if adjustments.empty?
+      p No adjustments have been submitted yet.
+    - else
       table
         thead
           tr
@@ -11,4 +13,8 @@
             th Actions
         tbody
           - adjustments.each do |adjustment|
-            = react_component('AdjustmentReview', { adjustment: adjustment, student_name: adjustment.checkin.student.decorate.pretty_name, checkin_status: adjustment.checkin.short_checkin_status}, tag: :tr )
+            = react_component('AdjustmentReview', { \
+                adjustment: adjustment, \
+                student_name: adjustment.checkin.student.decorate.pretty_name, \
+                checkin_status: adjustment.checkin.short_checkin_status \
+              }, tag: :tr )

--- a/app/views/staff/cohorts/_attendance.html.slim
+++ b/app/views/staff/cohorts/_attendance.html.slim
@@ -29,6 +29,6 @@
   .card.blue.darken-3
     .card-content.white-text
       span.card-title = t('.attendance')
-      p No day has been created for today
+      p No day has been created for today.
     .card-action
       = link_to "Add Day", new_staff_cohort_day_path(cohort), class: ""

--- a/app/views/staff/cohorts/_ungraded_assignments.slim
+++ b/app/views/staff/cohorts/_ungraded_assignments.slim
@@ -1,4 +1,11 @@
-- unless cohort.ungraded_submissions.empty?
+- if cohort.ungraded_submissions.empty?
+  .card.blue.darken-3
+    .card-content.white-text
+      span.card-title Ungraded Assignments
+      p No assignments to grade. Great job!
+    .card-action
+      = link_to "Add Assignment", new_staff_cohort_assignment_path(cohort), class: ""
+- else
   .card.blue.darken-3
     .card-content.white-text
       span.card-title Ungraded Assignments
@@ -6,7 +13,7 @@
         ul.collapsible.popout data-collapsible="accordion"
           li.full-width
             .collapsible-header.black-text
-              = truncate(assignment.title.titleize, length: 55) 
+              = truncate(assignment.title.titleize, length: 55)
               = link_to material_icon.assignment, staff_cohort_assignment_path(assignment.cohort, assignment), class: "secondary-content"
             .collapsible-body
               ul.collection

--- a/app/views/staff/cohorts/show.slim
+++ b/app/views/staff/cohorts/show.slim
@@ -1,15 +1,13 @@
 = render partial: 'nav', locals: { cohort: cohort }
 .col.s4
   p.muted Student Signup:
-  = cohort.sign_up_url
+  span.right-space id='cohort-signup-url' = cohort.sign_up_url
+  a.btn-floating.waves-effect.waves-light.copy-to-clipboard-button id='cohort-signup-link-button' data-clipboard-target='cohort-signup-url' title='Click to copy cohort sign up url to clipboard'
+    i.material-icons description
 
-- if cohort.students.empty? && adjustments.empty? && !cohort.current_day
-  .row
-    h4.col.offset-l2.l8.m10.offset-m1.s12 Nothing going on with this cohort yet!
-- else
-  .row
-    .col.l6.m6 = render partial: 'ungraded_assignments', locals: { cohort: cohort }
-    .col.l6.m6 = render partial: 'attendance',  locals: { cohort: cohort }
-  .row
-    .col.l6.m12 = render partial: 'students', locals: { students: cohort.students.decorate }
-    .col.l6.m12 = render partial: 'adjustments', locals: { adjustments: adjustments }
+.row
+  .col.l6.m6 = render partial: 'ungraded_assignments', locals: { cohort: cohort }
+  .col.l6.m6 = render partial: 'attendance',  locals: { cohort: cohort }
+.row
+  .col.l6.m12 = render partial: 'students', locals: { students: cohort.students.decorate }
+  .col.l6.m12 = render partial: 'adjustments', locals: { adjustments: adjustments }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,6 +20,19 @@ instructor = Instructor.create!({
   user: user
 })
 
+Instructor.create!({
+  phone: '555 555 5555',
+  office_hours_start: "March 22, 2015 12:00PM",
+  office_hours_end: "March 22, 2015 5:00PM",
+  user: new_instructor = User.create!({
+    email: 'new-instructor@example.com',
+    password: 'password',
+    name: "Okay Instructor"
+  })
+})
+new_instructor.confirm
+new_instructor.save!
+
 user2 = User.create!({
   email: 'student@example.com',
   password: 'password'
@@ -72,4 +85,3 @@ end
     assignment_id: assignments.sample.id
   })
 end
-


### PR DESCRIPTION
- All modules present an 'empty state' for new instructors
- Days prompt creating a new day
- Assignments prompt creating an assignment
- Students prompt copying the signup url.

- Added ZeroClipboard for autocopying the signup url.
- Used ZeroClipboard for the assignment URL as well.

## Instructor Dashboard for new instructors/cohorts
<img width="979" alt="screen shot 2015-10-14 at 5 58 29 pm" src="https://cloud.githubusercontent.com/assets/249209/10500571/c80d14e6-729e-11e5-9eca-1b179b4983f9.png">

## Assignment URL copy button
<img width="418" alt="screen shot 2015-10-14 at 6 07 09 pm" src="https://cloud.githubusercontent.com/assets/249209/10500572/cb1f36b4-729e-11e5-8624-2918f621ef25.png">
