### PR TITLE
Ability to update a report as staff, with existing edit button

### DIFF
--- a/app/controllers/staff/reports_controller.rb
+++ b/app/controllers/staff/reports_controller.rb
@@ -38,6 +38,17 @@ class Staff::ReportsController < Staff::ApplicationController
     end
   end
 
+  def update
+    @report = Report.find(params[:id])
+    authorize @report
+    if @report.update report_params
+      redirect_to staff_cohort_report_path(@cohort, @report), notice: I18n.t('.updated', resource: I18n.t('.report'))
+    else
+      flash[:alert] = "Report couldn't be updated because #{@report.errors.full_messages.join(', ')}"
+      render :edit
+    end
+  end
+
   private
   def set_cohort
     @cohort = Cohort.find(params[:cohort_id]).decorate

--- a/app/views/staff/reports/_form.html.slim
+++ b/app/views/staff/reports/_form.html.slim
@@ -20,4 +20,4 @@ h2 Student Assessment Form
     .input-field.col.s12
       = f.select :status, Report.statuses.keys.map {|s| [s.titleize, s]}
       = f.label :status
-  = f.submit 'Create', class: 'btn'
+  = f.submit (f.object.new_record? ? 'Create' : 'Update'), class: 'btn'

--- a/spec/features/staff/reports_spec.rb
+++ b/spec/features/staff/reports_spec.rb
@@ -14,4 +14,16 @@ RSpec.feature "StaffReports", type: :feature do
       expect(page).to have_content("Bi-Weekly Performance")
     end
   end
+
+  feature 'Editing a report' do
+    scenario 'as the instructor' do
+      sign_in(instructor_user)
+      report = create :report, student: student
+      visit staff_cohort_report_path(cohort, report)
+      click_link "Edit"
+      select "2", from: "Participation"
+      click_button "Update"
+      expect(page).to have_content("Participation (2/3)")
+    end
+  end
 end


### PR DESCRIPTION
Here's that button
![classroom_and_jwos-macbook-air_ _-zsh_ _129x35](https://cloud.githubusercontent.com/assets/123075/10947539/0f5c6c52-82ee-11e5-8f89-9128576e07f9.png)
