### PR TITLE
Update Airbrake Heroku addon name

### DIFF
--- a/app.json
+++ b/app.json
@@ -50,7 +50,7 @@
         "image": "heroku/ruby",
         "addons":[
                 "papertrail:choklad",
-                "airbrake:free_heroku",
+                "airbrake:free-hrku",
                 "heroku-postgresql"
         ],
         "buildpacks": [


### PR DESCRIPTION
Airbrake has changed the name of their free plan on Heroku.
